### PR TITLE
Adjust positioning of characters remaining number

### DIFF
--- a/cortex_implant_styling.user.js
+++ b/cortex_implant_styling.user.js
@@ -2832,7 +2832,7 @@ body {
         grid-column: span 2 / -1;
 
         pointer-events: none;
-        translate: 0 -38px;
+        translate: -38px 0px;
       }
     }
   }


### PR DESCRIPTION
Fix alignment of characters remaining counter in the compose widget.

Instead of above emoji icon, now appears in compose form button row. I assume this was the original intent.

Before:
<img width="498" height="492" alt="image" src="https://github.com/user-attachments/assets/89897949-074b-47e5-b982-885de9d1b4e4" />

After:
<img width="488" height="492" alt="image" src="https://github.com/user-attachments/assets/44371264-fbc1-4a83-95f6-58e174636829" />
